### PR TITLE
README and build-in help cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
-# JPEGrescan: losslessly shrink any JPEG file 
-
+# JPEGrescan: losslessly shrink any JPEG file
 JPEGrescan is a perl script that uses jpeg tools to optimise jpeg compression by micro-managing some of the compression math based on research into some of the most common parameters.
 
 NB: [MozJPEG](https://github.com/mozilla/mozjpeg) has the same optimisation built-in and is faster, so we recommend using MozJPEG when possible.
 
 ## Usage
-
-```$ jpegrescan in.jpg out.jpg ```
+```$ jpegrescan in.jpg out.jpg```
 
 ### Arguments
-
-* -s: Removes all Exif data and now all JFIF data as well.  (A basic 18-byte JFIF segment is added in its place.)
+* -s: Removes all Exif data and now all JFIF data as well.  A basic 18-byte JFIF segment is added in its place.
 * -i: Allows optimisations that may be "incompatible" with some software.  Currently this means removing *all* JFIF data (saving 18 bytes) and allowing an encoding not supported by Opera before version 11.61.
-* -t: Turns on multithreaded operation.  Usually, uses up to 4 threads.  Faster, but not four times faster than without -t.  So try xargs -n1 -P to shrink a large number of jpegs at the same time.
-* -a: Turns on arithmetic coding. (Unsupported by most software.)  
-* -v: verbose output
-* -q: suppress all output
+* -t: Turns on multithreaded operation.  Usually, uses up to 4 threads.  Faster, but not four times faster than without _-t_.  So try _xargs -n1 -P_ to shrink a large number of jpegs at the same time.
+* -a: Turns on arithmetic coding.  Note this is unsupported by most software.
+* -v: Verbose output.
+* -q: Suppress all output.
 
-##Issues 
-* No out.jpg - Install the below packages to solve this issue
-  Fedora: yum -y install perl-File-Slurp libjpeg-turbo-utils 
-  Debian: aptitude install -y libfile-slurp-perl libjpeg-turbo-progs
+## Package Availability
+JPEGrescan is known to be packaged in the following distributions:
+* Arch's User Repository
+* NixOS
+
+## Issues
+* No out.jpg.  Install the following:
+  * Fedora: ```yum -y install perl-File-Slurp libjpeg-turbo-utils```
+  * Debian: ```aptitude install -y libfile-slurp-perl libjpeg-turbo-progs```
 
 ## Thanks
-
-First, thanks to **Loren Merritt** who created this script originally.  Also, thanks to the people on devshed.com and lyncd.com - whose names seem to be lost to the sands of time - who came up with the jfifremove idea and basic C code.
+First, thanks to **Loren Merritt** who created this script originally.  Also, thanks to the people on [devshed](https://www.devshed.com/) and [lyncd](https://lyncd.com/) - whose names seem to be lost to the sands of time - who came up with the jfifremove idea and the basic C code.

--- a/jpegrescan
+++ b/jpegrescan
@@ -9,12 +9,12 @@ require threads if $t;
 @ARGV==2 or die "usage: jpegrescan in.jpg out.jpg
 tries various progressive scan orders
 switches:
-  -s strip from all extra markers (`jpegtran -copy none` otherwise `jpegtran -copy all`)
-  -i allow optimizations that may be incompatible with some software (implies -s)
-  -t use multiple threads (usually 3.)  Faster, but not 3x faster.
-  -v verbose output
-  -q supress all output
-  -a use arithmetic coding (unsupported by most software)
+  -s Strip from all extra markers (`jpegtran -copy none` otherwise `jpegtran -copy all`).
+  -i Allow optimizations that may be incompatible with some software (implies -s).
+  -t Use multiple threads (usually 3).  Faster, but not 3x faster.
+  -a Use arithmetic coding. Unsupported by most software.
+  -v Verbose output.
+  -q Supress all output.
 ";
 $fin = $ARGV[0];
 $fout = $ARGV[1];
@@ -214,4 +214,3 @@ unlink $ftmp;
 for(my $i=0; $i <= $maxtries; $i++) {
   unlink $ftmp.$i;
 }
-


### PR DESCRIPTION
Cleanups and formatting. I've also made mention of the Arch's AUR and NixOS packages.

You might also be interested knowing there are jpegs in the wild MozJPEG fails to recognize and process while JPEGrescan handles fine.