### PR TITLE
Spelling

### DIFF
--- a/jpegrescan
+++ b/jpegrescan
@@ -176,7 +176,7 @@ if($rgb) {
 # refinement passes have some chance of being split (luma: 4%,4%,4%. chroma: 20%,8%) but the total bit gain is negligible.
 # msb pass should almost always be split (luma: 87%, chroma: 81%).
 # I have no theoretical reason for this list of split positions, they're just the most common in practice.
-# splitting into 3 ections is often slightly better, but the total number of bits saved is negligible.
+# splitting into 3 sections is often slightly better, but the total number of bits saved is negligible.
 # FIXME: penalize lots of refinement passes because it's slower to decode. if so, then also force overwrite if bigger than the input.
 sub try_splits {
     my $str = shift;

--- a/jpegrescan
+++ b/jpegrescan
@@ -14,7 +14,7 @@ switches:
   -t Use multiple threads (usually 3).  Faster, but not 3x faster.
   -a Use arithmetic coding. Unsupported by most software.
   -v Verbose output.
-  -q Supress all output.
+  -q Suppress all output.
 ";
 $fin = $ARGV[0];
 $fout = $ARGV[1];


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`